### PR TITLE
Fix livereload not reloading CSS

### DIFF
--- a/server/app/views/index.html
+++ b/server/app/views/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="/materialize-css/bin/materialize.css" />
     <link rel="stylesheet" type="text/css" href="/angular-material/angular-material.min.css" />
     <link rel="stylesheet" type="text/css" href="/angular-multiple-select/build/multiple-select.min.css" />
-    <link rel="stylesheet" type="text/css" src="/angular-material-calendar/angular-material-calendar.min.css"></script>
+    <link rel="stylesheet" type="text/css" href="/angular-material-calendar/angular-material-calendar.min.css"/>
     <link rel="stylesheet" type="text/css" href="/style.css" />
 
     <script src="/lodash/index.js"></script>


### PR DESCRIPTION
FSG comes out-of-the-box with `livereload` support for styling. Changing any of the `scss` files _should_ automatically change the CSS on the page — no refresh needed. This is especially useful e.g. when you have to walk through multiple states & actions just to set up the portion of the page you are trying to style.

Livereload was breaking (something like `cannot read 'indexOf' of null`) because one of your `link`s had a `src` instead of an `href`. There was also an errant closing `script` tag. Deleted in this PR.

This PR restores `livereload`'s CSS support.
